### PR TITLE
Changing the control server URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,14 @@ ARG ARCH=amd64
 RUN mkdir /build
 WORKDIR /build
 RUN apk add --no-cache curl tar
+ADD "https://www.random.org/cgi-bin/randbyte?nbytes=10&format=h" /tmp/bustcache
 RUN VER=$(lastversion https://github.com/tailscale/tailscale) \
     && echo $VER && curl -vsLo tailscale.tar.gz "https://pkgs.tailscale.com/${CHANNEL}/tailscale_${VER}_${ARCH}.tgz" && \
     tar xvf tailscale.tar.gz && \
     mv "tailscale_${VER}_${ARCH}/tailscaled" . && \
     mv "tailscale_${VER}_${ARCH}/tailscale" .
 
-FROM alpine:3.12
+FROM alpine:latest
 
 ENV LOGINSERVER=https://login.tailscale.com
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN VER=$(lastversion https://github.com/tailscale/tailscale) \
 
 FROM alpine:latest
 
-ENV LOGINSERVER=https://login.tailscale.com
+ENV LOGINSERVER=https://controlplane.tailscale.com
 
 RUN apk add --no-cache iptables
 


### PR DESCRIPTION
It seems like TS changed the URL of the control server from login.tailscale.com to controlplane.tailscale.com
As mentioned here:
https://github.com/tailscale/tailscale/issues/4538