### PR TITLE
Fix to deal with zombie process on host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,14 @@ ENV LOGINSERVER=https://controlplane.tailscale.com
 
 RUN apk add --no-cache iptables
 
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.sha256sum /tini.sha256sum
+RUN echo "$(cat /tini.sha256sum)" | sha256sum -c && chmod +x /tini
+
 COPY --from=builder /build/tailscale /usr/bin/
 COPY --from=builder /build/tailscaled /usr/bin/
 
 COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "/bin/sh", "/entrypoint.sh"]


### PR DESCRIPTION
This fix will supply the container with a minimalistic init system running as PID 1 and any process that’s also supposed to be in the container being started by the init system directly after, proxying any signals the container receives through to the actual application process. This will not cause a zombie process to show up on the host.

More here... https://worp.io/docker-and-zombie-processes-pid-1-in-containers/